### PR TITLE
Producing dot files

### DIFF
--- a/lib/mix/tasks/boundary/visualize.ex
+++ b/lib/mix/tasks/boundary/visualize.ex
@@ -1,0 +1,51 @@
+defmodule Mix.Tasks.Boundary.Visualize do
+  @shortdoc "Generates a graphviz a dot file for each non-empty boundary."
+  @moduledoc "Generates a graphviz a dot file for each non-empty boundary."
+
+  use Boundary, classify_to: Boundary.Mix
+  use Mix.Task
+
+  @output_folder "dot"
+
+  @impl Mix.Task
+  def run(_argv) do
+    name = "Test.Graph"
+    edges = [{"A", "B"}, {"A", "C"}, {"B", "C", style: :dotted}]
+    output_graph(name, edges)
+  end
+
+  def output_graph(name, edges) do
+    content = format_graph(name, edges)
+    write_graph(name, content)
+    :ok
+  end
+
+  defp write_graph(name, content) do
+    output_path = Path.join([File.cwd!(), @output_folder])
+    dotfile_path = Path.join(output_path, "#{name}.dot")
+    pngfile_path = Path.join(output_path, "#{name}.png")
+    File.mkdir(output_path)
+    File.write!(dotfile_path, content)
+    # System.cmd("dot", ["-Tpng", dotfile_path, "-o", pngfile_path])
+    # System.cmd("open", [pngfile_path])
+    # Process.sleep(5000)
+  end
+
+  defp format_graph(title, edges) do
+    """
+    digraph {
+      #{edges |> Enum.map(&format_edge/1) |> Enum.join("\n  ")}
+
+      label="#{title}";
+      labelloc=top;
+    }
+    """
+  end
+
+  defp format_edge({node1, node2}), do: format_edge({node1, node2, []})
+  defp format_edge({node1, node2, attributes}), do: "#{node1} -> #{node2}#{format_attributes(attributes)}"
+
+  defp format_attributes([]), do: ""
+  defp format_attributes(attributes), do: " [#{attributes |> Enum.map(&format_attribute/1) |> Enum.join(", ")}]"
+  defp format_attribute({name, value}), do: "#{name} = #{value}"
+end

--- a/lib/mix/tasks/boundary/visualize.ex
+++ b/lib/mix/tasks/boundary/visualize.ex
@@ -9,37 +9,55 @@ defmodule Mix.Tasks.Boundary.Visualize do
 
   @impl Mix.Task
   def run(_argv) do
-    name = "Test.Graph"
-    edges = [{"A", "B"}, {"A", "C"}, {"B", "C", style: :dotted}]
-    output_graph(name, edges)
-  end
+    Mix.Task.run("compile")
+    Boundary.Mix.load_app()
 
-  def output_graph(name, edges) do
-    content = format_graph(name, edges)
-    write_graph(name, content)
+    app_name = Boundary.Mix.app_name()
+
+    graph =
+      format_graph(
+        "#{app_name} application",
+        app_name
+        |> Boundary.view()
+        |> Boundary.all()
+        |> Stream.filter(&(&1.app == Boundary.Mix.app_name()))
+        |> Stream.reject(&Enum.empty?(&1.deps))
+        |> Stream.filter(&Enum.empty?(&1.ancestors))
+        |> Enum.sort_by(& &1.name)
+        |> Enum.flat_map(&boundary_to_edges/1)
+      )
+
+    write_graph("app", graph) |> draw_graph
+
     :ok
   end
 
-  defp write_graph(name, content) do
-    output_path = Path.join([File.cwd!(), @output_folder])
-    dotfile_path = Path.join(output_path, "#{name}.dot")
-    pngfile_path = Path.join(output_path, "#{name}.png")
-    File.mkdir(output_path)
-    File.write!(dotfile_path, content)
-    # System.cmd("dot", ["-Tpng", dotfile_path, "-o", pngfile_path])
-    # System.cmd("open", [pngfile_path])
-    # Process.sleep(5000)
+  defp boundary_to_edges(%{name: name, deps: deps}) do
+    boundary_node = format_node(name)
+
+    deps
+    |> Enum.sort()
+    |> Enum.map(fn {name, _mode} ->
+      dep_node = format_node(name)
+      {boundary_node, dep_node}
+    end)
   end
 
   defp format_graph(title, edges) do
     """
     digraph {
-      #{edges |> Enum.map(&format_edge/1) |> Enum.join("\n  ")}
+      #{edges |> Enum.map(&format_edge/1) |> Enum.join(";\n  ")};
 
       label="#{title}";
       labelloc=top;
     }
     """
+  end
+
+  def format_node(module_name) do
+    module_name
+    |> Module.split()
+    |> Enum.join(".")
   end
 
   defp format_edge({node1, node2}), do: format_edge({node1, node2, []})
@@ -48,4 +66,21 @@ defmodule Mix.Tasks.Boundary.Visualize do
   defp format_attributes([]), do: ""
   defp format_attributes(attributes), do: " [#{attributes |> Enum.map(&format_attribute/1) |> Enum.join(", ")}]"
   defp format_attribute({name, value}), do: "#{name} = #{value}"
+
+  defp write_graph(name, content) do
+    output_path = Path.join([File.cwd!(), @output_folder])
+    dot_file_path = Path.join(output_path, "#{name}.dot")
+    File.mkdir(output_path)
+    File.write!(dot_file_path, content)
+    dot_file_path
+  end
+
+  defp draw_graph(dot_file_path) do
+    image_dir_path = Path.dirname(dot_file_path)
+    image_file_name = Path.basename(dot_file_path, ".dot")
+    image_file_path = Path.join([image_dir_path, "#{image_file_name}.png"]) |> IO.inspect()
+    System.cmd("dot", ["-Tpng", dot_file_path, "-o", image_file_path])
+    System.cmd("open", [image_file_path])
+    Process.sleep(1000)
+  end
 end

--- a/lib/mix/tasks/boundary/visualize.ex
+++ b/lib/mix/tasks/boundary/visualize.ex
@@ -79,7 +79,7 @@ defmodule Mix.Tasks.Boundary.Visualize do
   end
 
   def format_node_description({module, :sibling}), do: format_node(module)
-  def format_node_description({module, _}), do: "#{format_node(module)} [color = \"gray\"]"
+  def format_node_description({module, _}), do: ~s/#{format_node(module)} [color = "gray"]/
 
   defp format_edges(edges) do
     edges
@@ -93,7 +93,7 @@ defmodule Mix.Tasks.Boundary.Visualize do
   end
 
   def format_node(module) when is_atom(module) do
-    "\"#{format_name(module)}\""
+    ~s/"#{format_name(module)}"/
   end
 
   defp format_name(module) when is_atom(module) do
@@ -103,5 +103,5 @@ defmodule Mix.Tasks.Boundary.Visualize do
   end
 
   defp format_edge_attributes(_node = {_, _, :runtime}), do: ""
-  defp format_edge_attributes(_node = {_, _, :compile}), do: " [label = \"compile\"]"
+  defp format_edge_attributes(_node = {_, _, :compile}), do: ~s/ [label = "compile"]/
 end

--- a/lib/mix/tasks/boundary/visualize.ex
+++ b/lib/mix/tasks/boundary/visualize.ex
@@ -33,13 +33,10 @@ defmodule Mix.Tasks.Boundary.Visualize do
   end
 
   defp boundary_to_edges(%{name: name, deps: deps}) do
-    boundary_node = format_node(name)
-
     deps
     |> Enum.sort()
-    |> Enum.map(fn {name, _mode} ->
-      dep_node = format_node(name)
-      {boundary_node, dep_node}
+    |> Enum.map(fn {dep_name, mode} ->
+      {name, dep_name, mode}
     end)
   end
 
@@ -54,18 +51,19 @@ defmodule Mix.Tasks.Boundary.Visualize do
     """
   end
 
+  defp format_edge({node1, node2}), do: format_edge({node1, node2, []})
+
+  defp format_edge({node1, node2, mode}),
+    do: "#{format_node(node1)} -> #{format_node(node2)}#{format_attributes(mode)}"
+
   def format_node(module_name) do
     module_name
     |> Module.split()
     |> Enum.join(".")
   end
 
-  defp format_edge({node1, node2}), do: format_edge({node1, node2, []})
-  defp format_edge({node1, node2, attributes}), do: "#{node1} -> #{node2}#{format_attributes(attributes)}"
-
-  defp format_attributes([]), do: ""
-  defp format_attributes(attributes), do: " [#{attributes |> Enum.map(&format_attribute/1) |> Enum.join(", ")}]"
-  defp format_attribute({name, value}), do: "#{name} = #{value}"
+  defp format_attributes(:runtime), do: ""
+  defp format_attributes(:compile), do: " [style = dashed, color = gray, label = \"compile\"]"
 
   defp write_graph(name, content) do
     output_path = Path.join([File.cwd!(), @output_folder])

--- a/lib/mix/tasks/boundary/visualize.ex
+++ b/lib/mix/tasks/boundary/visualize.ex
@@ -51,12 +51,12 @@ defmodule Mix.Tasks.Boundary.Visualize do
   end
 
   defp format_file_path(boundary) do
-    name = if is_nil(boundary), do: "app", else: format_name(boundary.name)
+    name = if is_nil(boundary), do: "app", else: inspect(boundary.name)
     Path.join([File.cwd!(), @output_folder, "#{name}.dot"])
   end
 
   defp format_title(nil), do: "#{Boundary.Mix.app_name()} application"
-  defp format_title(boundary), do: "#{format_name(boundary.name)} boundary"
+  defp format_title(boundary), do: "#{inspect(boundary.name)} boundary"
 
   defp format_graph(title, nodes, edges) do
     """
@@ -93,13 +93,7 @@ defmodule Mix.Tasks.Boundary.Visualize do
   end
 
   def format_node(module) do
-    ~s/"#{format_name(module)}"/
-  end
-
-  defp format_name(module) do
-    module
-    |> Module.split()
-    |> Enum.join(".")
+    ~s/"#{inspect(module)}"/
   end
 
   defp format_edge_attributes(_node = {_, _, :runtime}), do: ""

--- a/lib/mix/tasks/boundary/visualize.ex
+++ b/lib/mix/tasks/boundary/visualize.ex
@@ -21,7 +21,7 @@ defmodule Mix.Tasks.Boundary.Visualize do
     |> Enum.group_by(&Boundary.parent(view, &1))
     |> Enum.each(fn {main_boundary, boundaries} ->
       nodes = build_nodes(main_boundary, boundaries)
-      edges = build_edges(main_boundary, boundaries)
+      edges = build_edges(boundaries)
       title = format_title(main_boundary)
       graph = format_graph(title, nodes, edges)
       file_path = format_file_path(main_boundary)
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.Boundary.Visualize do
     end
   end
 
-  defp build_edges(_main_boundary, boundaries) do
+  defp build_edges(boundaries) do
     boundaries
     |> Enum.flat_map(fn %{name: name, deps: deps} ->
       Enum.map(deps, fn {dep_name, mode} ->

--- a/lib/mix/tasks/boundary/visualize.ex
+++ b/lib/mix/tasks/boundary/visualize.ex
@@ -27,11 +27,6 @@ defmodule Mix.Tasks.Boundary.Visualize do
       file_path = format_file_path(main_boundary)
 
       File.write!(file_path, graph)
-
-      # image_file_path = "#{Path.rootname(file_path)}.png"
-      # System.cmd("dot", ["-Tpng", file_path, "-o", image_file_path])
-      # System.cmd("open", [image_file_path])
-      # Process.sleep(1000)
     end)
 
     :ok

--- a/lib/mix/tasks/boundary/visualize.ex
+++ b/lib/mix/tasks/boundary/visualize.ex
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.Boundary.Visualize do
   use Boundary, classify_to: Boundary.Mix
   use Mix.Task
 
-  @output_folder "dot"
+  @output_folder "boundary"
 
   @impl Mix.Task
   def run(_argv) do

--- a/lib/mix/tasks/boundary/visualize.ex
+++ b/lib/mix/tasks/boundary/visualize.ex
@@ -92,11 +92,11 @@ defmodule Mix.Tasks.Boundary.Visualize do
     "#{format_node(module1)} -> #{format_node(module2)}#{format_edge_attributes(edge)}"
   end
 
-  def format_node(module) when is_atom(module) do
+  def format_node(module) do
     ~s/"#{format_name(module)}"/
   end
 
-  defp format_name(module) when is_atom(module) do
+  defp format_name(module) do
     module
     |> Module.split()
     |> Enum.join(".")

--- a/test/mix/tasks/visualize_test.exs
+++ b/test/mix/tasks/visualize_test.exs
@@ -6,21 +6,62 @@ defmodule Mix.Tasks.Boundary.VisualizeTest do
     Mix.shell(Mix.Shell.Process)
     Logger.disable(self())
 
-    TestProject.run_task("boundary.visualize")
+    TestProject.in_project(fn project ->
+      File.write!(
+        Path.join([project.path, "lib", "source.ex"]),
+        """
+        defmodule BlogEngine do
+          use Boundary
 
-    test_output_file(
-      Path.join([File.cwd!(), "dot", "Test.Graph.dot"]),
-      """
-      digraph {
-        A -> B
-        A -> C
-        B -> C [style = dotted]
+          defmodule Repo do end
+          defmodule Accounts do
+            use Boundary, deps: [Repo]
+          end
+          defmodule Articles do
+            use Boundary, deps: [Repo, Accounts]
+          end
+        end
 
-        label=\"Test.Graph\";
-        labelloc=top;
-      }
-      """
-    )
+        defmodule BlogEngineWeb do
+          use Boundary, deps: [BlogEngine], exports: []
+        end
+
+        defmodule BlogEngineApp do
+          use Boundary, deps: [BlogEngineWeb, BlogEngine], exports: []
+        end
+        """
+      )
+
+      TestProject.run_task("boundary.visualize")
+
+      test_output_file(
+        Path.join([project.path, "dot", "app.dot"]),
+        """
+        digraph {
+          BlogEngineApp -> BlogEngine;
+          BlogEngineApp -> BlogEngineWeb;
+          BlogEngineWeb -> BlogEngine;
+
+          label="test_project_2 application";
+          labelloc=top;
+        }
+        """
+      )
+
+      # test_output_file(
+      #   Path.join([project.path, "dot", "BlogEngine.dot"]),
+      #   """
+      #   digraph {
+      #     Articles -> Accounts;
+      #     Articles -> Repo;
+      #     Accounts -> Repo;
+
+      #     label="test_project_2 boundary";
+      #     labelloc=top;
+      #   }
+      #   """
+      # )
+    end)
   end
 
   def test_output_file(path, content) do

--- a/test/mix/tasks/visualize_test.exs
+++ b/test/mix/tasks/visualize_test.exs
@@ -35,7 +35,7 @@ defmodule Mix.Tasks.Boundary.VisualizeTest do
       TestProject.run_task("boundary.visualize")
 
       test_output_file(
-        Path.join([project.path, "dot", "app.dot"]),
+        Path.join([project.path, "boundary", "app.dot"]),
         """
         digraph {
           label="#{project.app} application";
@@ -55,7 +55,7 @@ defmodule Mix.Tasks.Boundary.VisualizeTest do
       )
 
       test_output_file(
-        Path.join([project.path, "dot", "BlogEngine.dot"]),
+        Path.join([project.path, "boundary", "BlogEngine.dot"]),
         """
         digraph {
           label="BlogEngine boundary";

--- a/test/mix/tasks/visualize_test.exs
+++ b/test/mix/tasks/visualize_test.exs
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.Boundary.VisualizeTest do
 
           "BlogEngineApp" -> "BlogEngine";
           "BlogEngineApp" -> "BlogEngineWeb";
-          "BlogEngineApp" -> "Mix" [label = \"compile\"];
+          "BlogEngineApp" -> "Mix" [label = "compile"];
           "BlogEngineWeb" -> "BlogEngine";
         }
         """
@@ -67,7 +67,7 @@ defmodule Mix.Tasks.Boundary.VisualizeTest do
           "Mix" [color = \"gray\"];
 
           "BlogEngine.Accounts" -> "BlogEngine.Repo";
-          "BlogEngine.Accounts" -> "Mix" [label = \"compile\"];
+          "BlogEngine.Accounts" -> "Mix" [label = "compile"];
           "BlogEngine.Articles" -> "BlogEngine.Accounts";
           "BlogEngine.Articles" -> "BlogEngine.Repo";
         }

--- a/test/mix/tasks/visualize_test.exs
+++ b/test/mix/tasks/visualize_test.exs
@@ -1,0 +1,30 @@
+defmodule Mix.Tasks.Boundary.VisualizeTest do
+  use ExUnit.Case, async: false
+  alias Boundary.TestProject
+
+  test "produces the expected files output" do
+    Mix.shell(Mix.Shell.Process)
+    Logger.disable(self())
+
+    TestProject.run_task("boundary.visualize")
+
+    test_output_file(
+      Path.join([File.cwd!(), "dot", "Test.Graph.dot"]),
+      """
+      digraph {
+        A -> B
+        A -> C
+        B -> C [style = dotted]
+
+        label=\"Test.Graph\";
+        labelloc=top;
+      }
+      """
+    )
+  end
+
+  def test_output_file(path, content) do
+    assert File.exists?(path)
+    assert File.read!(path) =~ content
+  end
+end


### PR DESCRIPTION
Implementation for #15, adds a new mix task `boundary.visualize` that outputs graphviz diagrams per the spec described in the issue.

Right now it just generates a dummy simple graph output.