### PR TITLE
@moduledoc metadata

### DIFF
--- a/lib/boundary/definition.ex
+++ b/lib/boundary/definition.ex
@@ -20,7 +20,14 @@ defmodule Boundary.Definition do
   end
 
   @doc false
-  defmacro __before_compile__(_) do
+  defmacro __before_compile__(_env) do
+    module_doc_meta =
+      if Mix.Project.config()[:boundary][:docs_meta] do
+        quote do
+          @moduledoc boundary: :yes
+        end
+      end
+
     quote do
       Module.register_attribute(__MODULE__, Boundary, persist: true, accumulate: false)
 
@@ -38,6 +45,8 @@ defmodule Boundary.Definition do
           mix_task?: mix_task?
         }
       )
+
+      unquote(module_doc_meta)
     end
   end
 

--- a/test/doc_test.exs
+++ b/test/doc_test.exs
@@ -1,0 +1,81 @@
+defmodule Boundary.DocTest do
+  use ExUnit.Case, async: false
+  alias Boundary.TestProject
+
+  test "Does add moduledoc meta when configured to do so" do
+    Mix.shell(Mix.Shell.Process)
+    Logger.disable(self())
+
+    TestProject.in_project(
+      [mix_opts: [project_opts: [boundary: [docs_meta: true]]]],
+      fn project ->
+        TestProject.run_task("deps.compile")
+
+        File.write!(
+          Path.join([project.path, "lib", "source.ex"]),
+          """
+          defmodule Boundary1 do
+            use Boundary
+          end
+          """
+        )
+
+        TestProject.run_task("compile")
+
+        assert {:docs_v1, _, :elixir, _, _, %{boundary: _}, _} = Code.fetch_docs(Boundary1)
+      end
+    )
+  end
+
+  test "Does add moduledoc meta to all modules of a boundary when configured to do so" do
+    Mix.shell(Mix.Shell.Process)
+    Logger.disable(self())
+
+    TestProject.in_project(
+      [mix_opts: [project_opts: [boundary: [docs_meta: true]]]],
+      fn project ->
+        TestProject.run_task("deps.compile")
+
+        File.write!(
+          Path.join([project.path, "lib", "source.ex"]),
+          """
+          defmodule Boundary1 do
+            use Boundary
+
+            defmodule Foo do end
+          end
+          """
+        )
+
+        TestProject.run_task("compile")
+
+        assert {:docs_v1, _, :elixir, _, _, %{boundary: _}, _} = Code.fetch_docs(Boundary1.Foo)
+      end
+    )
+  end
+
+  test "Does not add moduledoc meta when not configured to do so" do
+    Mix.shell(Mix.Shell.Process)
+    Logger.disable(self())
+
+    TestProject.in_project(
+      [mix_opts: [project_opts: [boundary: [docs_meta: false]]]],
+      fn project ->
+        File.write!(
+          Path.join([project.path, "lib", "source.ex"]),
+          """
+          defmodule Boundary1 do
+            use Boundary
+          end
+          """
+        )
+
+        TestProject.run_task("compile")
+
+        {:docs_v1, _, :elixir, _, _, meta, _} = Code.fetch_docs(Boundary1)
+
+        refute Map.has_key?(meta, :boundary)
+      end
+    )
+  end
+end


### PR DESCRIPTION
This might actually be a bit more difficult than expected.

It seems simple to add moduledoc metadata to all the modules having a `use Boundary`, but what about the modules implicitly bound to that boundary.

And the other factor is: Do we at this point actually already know the relevant data about the boundary so it can be set as metadata? For the boundary roots – maybe. For modules implicitly part of a boundary – unlikely.