### PR TITLE
Update README to remove warning about Boundary being untested

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Boundary is a library which helps managing and restraining cross-module dependen
 
 ## Status
 
-This library has been used in smaller production projects for about a year. It is not tested on larger and umbrella projects. In case you experience problems, create an issue. In addition, be aware that Boundary loads the application and all of its dependencies (recursively) during compilation.
+This library has been used in smaller production projects for about a year, and while it has not been tested on larger projects or umbrella projects, no issues are expected in those cases. That being said, if you do run into problems, please open an issue!
 
 ## Documentation
 


### PR DESCRIPTION
I heard you mention on ThinkingElixir that the library has now been tested in production for over a year. Removing this warning would help me (and likely others!) get permission to deploy the library ourselves.