### PR TITLE
Allow re-exporting from sub boundaries

### DIFF
--- a/lib/boundary.ex
+++ b/lib/boundary.ex
@@ -473,9 +473,27 @@ defmodule Boundary do
   sub-boundaries.
 
   This demonstrates the main purpose of sub-boundaries. They are a mechanism which allows you to control the
-  dependencies within the parent boundary. The parent boundary still gets to decide which of these sub-modules will it
+  dependencies within the parent boundary. The parent boundary still gets to decide which of these sub-modules it will
   export. In this example, `Articles` and `Accounts` are exported, while `Repo` isn't. The sub-boundaries decide what
   will they depend on themselves.
+
+  ### Exporting From Sub-Boundaries
+
+  The parent boundary may also re-export modules that are exported by its sub-boundaries. In the above example, if the
+  `Articles` context exports a struct (or Ecto schema) module named `Article`, then `BlogEngine` can choose to re-export
+  that module.
+
+  ```
+  defmodule BlogEngine do
+    use Boundary, exports: [Accounts, Articles, Articles.Article]
+  end
+
+  defmodule BlogEngine.Articles do
+    use Boundary, deps: [BlogEngine.{Accounts, Repo}], exports: [Article]
+  end
+  ```
+
+  The parent boundary may not export a module that isn't exported by its owner boundary.
 
   ### Dependencies
 

--- a/lib/boundary.ex
+++ b/lib/boundary.ex
@@ -178,7 +178,7 @@ defmodule Boundary do
 
   ## Dependencies
 
-  Each boundary may depend on other boundaries. These dependencies are used to defined allowed
+  Each boundary may depend on other boundaries. These dependencies are used to define allowed
   cross-boundary module usage. A module from another boundary may only be used if:
 
     - The callee boundary is a direct dependency of the caller boundary.
@@ -234,7 +234,7 @@ defmodule Boundary do
   boundary specifies `Ecto.Query` as a dependency, while another references `Ecto.Query.API`, then two boundaries are
   defined, and the latter will not be a part of the former.
 
-  In some cases you may want to completely prohibit the usage of some library. However, bare in mind that by default
+  In some cases you may want to completely prohibit the usage of some library. However, bear in mind that by default
   calls to an external application are restricted only if the client boundary references at least one dep boundary from
   that application. To force boundary to always restrict calls to some application, you can include the application in
   the check apps list:

--- a/lib/boundary/checker.ex
+++ b/lib/boundary/checker.ex
@@ -173,14 +173,10 @@ defmodule Boundary.Checker do
   end
 
   defp to_boundaries(view, reference) do
-    to_boundary = Boundary.for_module(view, reference.to)
-
-    # main sub-boundary module may also be exported by its parent
-    parent_boundary =
-      if not is_nil(to_boundary) and reference.to == to_boundary.name,
-        do: Boundary.parent(view, to_boundary)
-
-    Enum.reject([to_boundary, parent_boundary], &is_nil/1)
+    case Boundary.for_module(view, reference.to) do
+      nil -> []
+      boundary -> [boundary | Enum.map(boundary.ancestors, &Boundary.fetch!(view, &1))]
+    end
   end
 
   defp reference_error(_view, _reference, %{check: %{out: false}}, _to_boundaries), do: nil


### PR DESCRIPTION
Closes #34 

Allow a boundary to re-export exports from its descendant boundaries.

This makes it possible to (for example) export the `App.Context.User` Ecto schema from `App` for use in `AppWeb`.

Also:
- fixed a couple of minor doc typos

Current state:
- I've implemented the test cases suggested in https://github.com/sasa1977/boundary/issues/34#issuecomment-950384115
- I have an implementation that allows the exports to work
- I'm still seeing `forbidden reference` errors when attempting to use one of these exports; I haven't had time (yet) to dig in and figure those out.

TODO:
- [x] Fix `forbidden reference` issues
- [ ] Update documentation

@sasa1977 I'd love your input on whether the tests look OK and any comments on the implementation. I'll leave a couple of line comments in specific spots where I'm especially curious.

<details><summary>Current test output</summary>
```shell
$ mix test
.....................................................

  1) test boundary can export a non-root export of a sub-boundary (Mix.Tasks.Compile.BoundaryTest)
     test/mix/tasks/compile/boundary_test.exs:738
     Assertion with == failed
     code:  assert warnings == []
     left:  [
              %{__struct__: Mix.Task.Compiler.Diagnostic, compiler_name: "boundary", details: nil, message: "forbidden reference to Module120.SubModule.Foo\n  (references from Module121 to Module120.SubModule are not allowed)", position: 13, severity: :warning}
            ]
     right: []
     stacktrace:
       test/mix/tasks/compile/boundary_test.exs:755: (test)

.........

  2) test boundary can export an export of a sub-sub-boundary (Mix.Tasks.Compile.BoundaryTest)
     test/mix/tasks/compile/boundary_test.exs:761
     Assertion with == failed
     code:  assert warnings == []
     left:  [
              %{__struct__: Mix.Task.Compiler.Diagnostic, compiler_name: "boundary", details: nil, message: "forbidden reference to Module122.SubBoundary.SubSubBoundary.Foo\n  (references from Module123 to Module122.SubBoundary.SubSubBoundary are not allowed)", position: 17, severity: :warning}
            ]
     right: []
     stacktrace:
       test/mix/tasks/compile/boundary_test.exs:782: (test)

....................

Finished in 25.4 seconds (1.1s async, 24.3s sync)
84 tests, 2 failures
```
</details>