### PR TITLE
Add infinite limit for ex_doc_groups

### DIFF
--- a/lib/boundary/mix/tasks/ex_doc_groups.ex
+++ b/lib/boundary/mix/tasks/ex_doc_groups.ex
@@ -73,7 +73,7 @@ defmodule Mix.Tasks.Boundary.ExDocGroups do
   end
 
   defp file_contents(header, data) do
-    [Code.format_string!(header <> inspect(data)), "\n"]
+    [Code.format_string!(header <> inspect(data, limit: :infinity)), "\n"]
   end
 
   defp module_name_to_group_key(name) do


### PR DESCRIPTION
When running `mix boundary.ex_doc_groups`, it can generate a `boundary.exs` file that contains `...` entries in the various arrays if there are boundaries with too many modules.

This adds a `limit: :infinity` option to the `inspect` call to avoid this problem.

We did not add a failing test for this, as we'd have had to add a lot more modules to `@module_setup` to expose the problem, and that felt like it might be too much clutter in the test.  We can do that if you want, however.