### PR TITLE
Simplify diagnostic handling

### DIFF
--- a/lib/boundary/mix/tasks/compile/boundary.ex
+++ b/lib/boundary/mix/tasks/compile/boundary.ex
@@ -394,31 +394,14 @@ defmodule Mix.Tasks.Compile.Boundary do
   end
 
   def diagnostic(message, opts \\ []) do
-    diagnostic =
-      %Mix.Task.Compiler.Diagnostic{
-        compiler_name: "boundary",
-        details: nil,
-        file: nil,
-        message: message,
-        position: 0,
-        severity: :warning
-      }
-      |> Map.merge(Map.new(opts))
-
-    cond do
-      diagnostic.file == nil ->
-        %{diagnostic | file: "unknown"}
-
-      diagnostic.position == 0 and File.exists?(diagnostic.file) ->
-        num_lines =
-          diagnostic.file
-          |> File.stream!()
-          |> Enum.count()
-
-        %{diagnostic | position: {1, 0, num_lines + 1, 0}}
-
-      true ->
-        diagnostic
-    end
+    %Mix.Task.Compiler.Diagnostic{
+      compiler_name: "boundary",
+      details: nil,
+      file: nil,
+      message: message,
+      position: 0,
+      severity: :warning
+    }
+    |> struct(opts)
   end
 end


### PR DESCRIPTION
* file should remain as nil if you can't pinpoint a source
* if there is no position (0), don't assume whole file

Boundary should provide the information it has and not assume.
The decisions of how to deal with incomplete data is a tooling choice.