### PR TITLE
Documentation: Reference Controlling Checks Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The configuration specifies the following rules:
   - Modules residing in the `MySystemWeb` boundary are allowed to invoke functions from modules exported by the `MySystem` boundary.
   - Modules residing in the `MySystem.Application` namespace are allowed to invoke functions from modules exported by `MySystem` and `MySystemWeb` boundaries.
 
-All other cross-boundary calls are not permitted.
+All other cross-boundary calls are not permitted.  In Phoenix projects this means you will require additional configuration to satisfy boundaries for modules generated inside `test/support/` folder. See the "Controlling Checks" section of the documentation for more details.
 
 Next, you need to add the mix compiler:
 

--- a/lib/boundary.ex
+++ b/lib/boundary.ex
@@ -42,6 +42,10 @@ defmodule Boundary do
     - `MySystem.Application` code may use `MySystem`, `MySystemWeb`, and `MySystemWeb.Endpoint`
       modules.
 
+  All other cross-boundary calls are not permitted.  In Phoenix projects this means you will 
+  require additional configuration to satisfy boundaries for modules generated inside 
+  `test/support/` folder. See the "Controlling Checks" section for more details.
+
   To enforce these rules on project compilation, you need to include the compiler in `mix.exs`:
 
   ```


### PR DESCRIPTION
👋 I was setting up Boundary for the first time, and using the README was able to get the "lib" folder configured right away.  When I ran my tests with the `--warnings-as-errors` flag I realized that I also needed some additional changes for the test/support code.

It took me a little while to find this blurb in [Controlling Checks](https://hexdocs.pm/boundary/Boundary.html#module-controlling-checks) section of the documentation:

> Ignoring checks can be useful for the test support modules

So this PR now mentions that section in the "typical Phoenix based project" section of the documentation.  Hopefully this will help other newcomers get up-and-running quickly.