### PR TITLE
Fix `funs` error: `no match of right hand side value: nil`

### DIFF
--- a/lib/boundary/mix/tasks/visualize/funs.ex
+++ b/lib/boundary/mix/tasks/visualize/funs.ex
@@ -41,7 +41,11 @@ defmodule Mix.Tasks.Boundary.Visualize.Funs do
 
   @doc false
   def trace({local, _meta, callee_fun, _arity}, env) when local in ~w/local_function local_macro/a do
-    {caller_fun, _arity} = env.function
+    {caller_fun, _arity} =
+      case env.function do
+        nil -> {:__module__, 0} # fallback name for non-function scope
+        tuple -> tuple
+      end
 
     if inspect(env.module) == :persistent_term.get({__MODULE__, :module}) and caller_fun != callee_fun,
       do: :ets.insert(__MODULE__, {caller_fun, callee_fun})

--- a/lib/boundary/mix/tasks/visualize/funs.ex
+++ b/lib/boundary/mix/tasks/visualize/funs.ex
@@ -41,14 +41,10 @@ defmodule Mix.Tasks.Boundary.Visualize.Funs do
 
   @doc false
   def trace({local, _meta, callee_fun, _arity}, env) when local in ~w/local_function local_macro/a do
-    {caller_fun, _arity} =
-      case env.function do
-        nil -> {:__module__, 0} # fallback name for non-function scope
-        tuple -> tuple
-      end
-
-    if inspect(env.module) == :persistent_term.get({__MODULE__, :module}) and caller_fun != callee_fun,
-      do: :ets.insert(__MODULE__, {caller_fun, callee_fun})
+    with {caller_fun, _arity} <- env.function,
+         true <- inspect(env.module) == :persistent_term.get({__MODULE__, :module}),
+         true <- caller_fun != callee_fun,
+         do: :ets.insert(__MODULE__, {caller_fun, callee_fun})
 
     :ok
   end


### PR DESCRIPTION
I encountered error:

```
== Compilation error in file lib/my_app/mailer.ex ==
** (MatchError) no match of right hand side value: nil
    (boundary 0.10.4) lib/boundary/mix/tasks/visualize/funs.ex:48: Mix.Tasks.Boundary.Visualize.Funs.trace/2
    (elixir 1.18.4) src/elixir_env.erl:30: :elixir_env."-trace/2-lc$^0/1-0-"/3
    (elixir 1.18.4) src/elixir_env.erl:30: :elixir_env.trace/2
```

This was due to a module like this:

```elixir
defmodule MyApp.Mailer do
  use Boundary, deps: [], exports: []
  use Swoosh.Mailer, otp_app: :my_app
end
```

The fallback in this commit allows `funs` mix command to run successfully.