### PR TITLE
perf (CompilerState.flush): Do nothing on no-op recompiles

### DIFF
--- a/lib/boundary/mix/compiler_state.ex
+++ b/lib/boundary/mix/compiler_state.ex
@@ -40,18 +40,38 @@ defmodule Boundary.Mix.CompilerState do
   def flush(app_modules) do
     app_modules = MapSet.new(app_modules)
 
-    for module <- ets_keys(references_table()),
-        not MapSet.member?(app_modules, module),
-        table <- [references_table(), modules_table()],
-        do: :ets.delete(table, module)
+    # Remove entries for modules that are no longer part of the app (e.g. their source was deleted).
+    deleted_any? =
+      Enum.reduce(ets_keys(references_table()), false, fn module, acc ->
+        if MapSet.member?(app_modules, module) do
+          acc
+        else
+          Enum.each([references_table(), modules_table()], &:ets.delete(&1, module))
+          true
+        end
+      end)
 
-    app_modules
+    # Only modules that were (re)compiled this run hold uncompressed entries; everything else was loaded
+    # from the manifest already compressed. Compressing those again would just reproduce identical data.
+    recompiled_modules =
+      seen_table()
+      |> ets_keys()
+      |> Enum.filter(&MapSet.member?(app_modules, &1))
+
+    recompiled_modules
     |> Enum.map(&Task.async(fn -> compress_entries(&1) end))
     |> Enum.each(&Task.await(&1, :infinity))
 
     :ets.delete_all_objects(seen_table())
-    :ets.tab2file(references_table(), to_charlist(Boundary.Mix.manifest_path("boundary_references")))
-    :ets.tab2file(modules_table(), to_charlist(Boundary.Mix.manifest_path("boundary_modules")))
+
+    # If nothing was recompiled or removed, the in-memory tables are identical to the manifests on disk,
+    # so there's no point rewriting them.
+    if deleted_any? or recompiled_modules != [] do
+      :ets.tab2file(references_table(), to_charlist(Boundary.Mix.manifest_path("boundary_references")))
+      :ets.tab2file(modules_table(), to_charlist(Boundary.Mix.manifest_path("boundary_modules")))
+    else
+      :ok
+    end
   end
 
   @doc "Returns a lazy stream where each element is of type `t:Boundary.ref()`"


### PR DESCRIPTION
On Jump's monorepo (~750k LoC), the performance hit of adding Boundary was minimal when running a full recompile (which was already in the range of 2 minutes). However, where it really hurt was on no-op compile jobs (regularly triggered by `mix test`, `mix ecto.setup`, etc.). In those cases, I was seeing Boundary add about 4 seconds to job which otherwise would have taken about 2 seconds.

After adding some `:timer.tc/1` profiling, I discovered the biggest culprit by far was `CompilerState.flush/1`, which took about 1.5 seconds. This patch speeds it up to about 30 ms by:

1. Only compressing modules which were actually recompiled
2. Only doing the (quite slow) `:ets.tab2file/2` dump when one or more modules were deleted or recompiled