### PR TITLE
perf (Checker): Check for errors in parallel

### DIFF
--- a/lib/boundary/checker.ex
+++ b/lib/boundary/checker.ex
@@ -4,14 +4,7 @@ defmodule Boundary.Checker do
 
   def errors(view, references) do
     references_count = length(references)
-
-    chunked_references =
-      if references_count > 0 do
-        Enum.chunk_every(references, ceil(references_count / System.schedulers_online()))
-      else
-        []
-      end
-
+    chunked_references = Enum.chunk_every(references, max(ceil(references_count / System.schedulers_online()), 1))
     all = Boundary.all(view)
 
     # Each check is a pure read over `view`/`references`, so they're safe to run
@@ -32,10 +25,8 @@ defmodule Boundary.Checker do
         fn -> unused_dirty_xrefs(view, all, references) end
       ] ++ Enum.map(chunked_references, &fn -> invalid_references(view, &1) end)
 
-    # We keep `ordered: true` so the downstream `uniq_by` (which keeps
-    # the first occurrence) sees results in the same order as the serial version.
     jobs
-    |> Task.async_stream(& &1.(), ordered: true, timeout: :infinity)
+    |> Task.async_stream(& &1.(), timeout: :infinity)
     |> Stream.flat_map(fn {:ok, errors} -> errors end)
     |> Enum.uniq_by(fn
       # deduping by reference minus type/mode, because even if those vary the error can still be the same

--- a/lib/boundary/checker.ex
+++ b/lib/boundary/checker.ex
@@ -3,17 +3,40 @@ defmodule Boundary.Checker do
   @moduledoc false
 
   def errors(view, references) do
-    Enum.concat([
-      invalid_config(view),
-      invalid_ignores(view),
-      ancestor_with_ignored_checks(view),
-      invalid_deps(view),
-      invalid_exports(view),
-      cycles(view),
-      unclassified_modules(view),
-      invalid_references(view, references),
-      unused_dirty_xrefs(view, references)
-    ])
+    references_count = length(references)
+
+    chunked_references =
+      if references_count > 0 do
+        Enum.chunk_every(references, ceil(references_count / System.schedulers_online()))
+      else
+        []
+      end
+
+    all = Boundary.all(view)
+
+    # Each check is a pure read over `view`/`references`, so they're safe to run
+    # concurrently.
+    #
+    # The invalid_references check is linear in the count of the references, but each reference
+    # can be checked independently of all others. Since there may be hundreds of thousands of them,
+    # we chunk the references so the chunks can run concurrently.
+    jobs =
+      [
+        fn -> invalid_config(all) end,
+        fn -> invalid_ignores(view, all) end,
+        fn -> ancestor_with_ignored_checks(view, all) end,
+        fn -> invalid_deps(view, all) end,
+        fn -> invalid_exports(view, all) end,
+        fn -> cycles(all) end,
+        fn -> unclassified_modules(view) end,
+        fn -> unused_dirty_xrefs(view, all, references) end
+      ] ++ Enum.map(chunked_references, &fn -> invalid_references(view, &1) end)
+
+    # We keep `ordered: true` so the downstream `uniq_by` (which keeps
+    # the first occurrence) sees results in the same order as the serial version.
+    jobs
+    |> Task.async_stream(& &1.(), ordered: true, timeout: :infinity)
+    |> Stream.flat_map(fn {:ok, errors} -> errors end)
     |> Enum.uniq_by(fn
       # deduping by reference minus type/mode, because even if those vary the error can still be the same
       {:invalid_reference, data} -> update_in(data.reference, &Map.drop(&1, [:type, :mode]))
@@ -21,26 +44,26 @@ defmodule Boundary.Checker do
     end)
   end
 
-  defp invalid_deps(view) do
-    for boundary <- Boundary.all(view),
+  defp invalid_deps(view, all) do
+    for boundary <- all,
         {dep, type} <- boundary.deps,
         error = validate_dep(view, boundary, dep, type),
         error != :ok,
         do: error
   end
 
-  defp invalid_config(view), do: view |> Boundary.all() |> Enum.flat_map(& &1.errors)
+  defp invalid_config(all), do: Enum.flat_map(all, & &1.errors)
 
-  defp invalid_ignores(view) do
-    for boundary <- Boundary.all(view),
+  defp invalid_ignores(view, all) do
+    for boundary <- all,
         boundary.app == view.main_app,
         not boundary.check.in or not boundary.check.out,
         not Enum.empty?(boundary.ancestors),
         do: {:invalid_ignores, boundary}
   end
 
-  defp ancestor_with_ignored_checks(view) do
-    for boundary <- Boundary.all(view),
+  defp ancestor_with_ignored_checks(view, all) do
+    for boundary <- all,
         boundary.app == view.main_app,
         ancestor <- Enum.map(boundary.ancestors, &Boundary.fetch!(view, &1)),
         not ancestor.check.in or not ancestor.check.out,
@@ -80,8 +103,8 @@ defmodule Boundary.Checker do
        else: {:forbidden_dep, %{name: to_boundary.name, file: from_boundary.file, line: from_boundary.line}}
   end
 
-  defp invalid_exports(view) do
-    for boundary <- Boundary.all(view),
+  defp invalid_exports(view, all) do
+    for boundary <- all,
         export <- exports_to_check(boundary),
         error = validate_export(view, boundary, export),
         into: MapSet.new(),
@@ -140,13 +163,13 @@ defmodule Boundary.Checker do
     end
   end
 
-  defp cycles(view) do
+  defp cycles(all) do
     graph = :digraph.new([:cyclic])
 
     try do
-      Enum.each(Boundary.all(view), &:digraph.add_vertex(graph, &1.name))
+      Enum.each(all, &:digraph.add_vertex(graph, &1.name))
 
-      for boundary <- Boundary.all(view),
+      for boundary <- all,
           {dep, _type} <- boundary.deps,
           do: :digraph.add_edge(graph, boundary.name, dep)
 
@@ -346,9 +369,9 @@ defmodule Boundary.Checker do
 
   defp export_matches?(_, _, _, _), do: false
 
-  defp unused_dirty_xrefs(view, references) do
+  defp unused_dirty_xrefs(view, all, references) do
     all_dirty_xrefs =
-      for boundary <- Boundary.all(view),
+      for boundary <- all,
           xref <- boundary.dirty_xrefs,
           into: MapSet.new(),
           do: {boundary.name, xref}


### PR DESCRIPTION
After the `CompilerState.flush` fix (#77), the next slowest operation on Jump's codebase was `Boundary.Checker.check/1`, which took about 450 ms whether it was a full recompile or a no-op.

This makes two changes that help that:

1. (The biggest:) Run the checks in parallel, and for the `invalid_references` check (which is linear in the number of references, but embarassingly parallel for each one), run batches of references as separate `Task`s.
2. As a minor benefit, avoid mapping over all the boundary definitions many times (extracting the `Boundary.all/1` call out of each check that needs it)

All told, this gets the checking step down to a consistently under 200 ms on Jump's codebase.