### PR TITLE
docs(ex_doc_groups): Pass reference to 0-arity function `docs/0`

### DIFF
--- a/lib/boundary/mix/tasks/ex_doc_groups.ex
+++ b/lib/boundary/mix/tasks/ex_doc_groups.ex
@@ -11,7 +11,7 @@ defmodule Mix.Tasks.Boundary.ExDocGroups do
           [
             …,
             aliases: aliases(),
-            docs: docs()
+            docs: &docs/0
           ]
         end
 


### PR DESCRIPTION
The current suggestion of the docs can cause all mix tasks to fail if the `boundary.exs` file is not present, as the `project/0` function is always called for each `mix` invocation.

This fix suggests using a function reference for `:docs` so that it can be only called when `mix docs` is called.